### PR TITLE
have a stricter check for the method

### DIFF
--- a/molpro_input.py
+++ b/molpro_input.py
@@ -114,7 +114,7 @@ def parse(input: str, allowed_methods: list, debug=False):
             if 'method' in specification: return {}  # input too complex
             if 'precursor_methods' not in specification: specification['precursor_methods'] = []
             specification['precursor_methods'].append(line.lower())
-        elif any([re.match('{?' + df_prefix + local_prefix + spin_prefix + method, command, flags=re.IGNORECASE) for
+        elif any([re.fullmatch('{?' + df_prefix + local_prefix + spin_prefix + method, command, flags=re.IGNORECASE) for
                   df_prefix
                   in df_prefixes
                   for local_prefix in local_prefixes for spin_prefix in spin_prefixes for method in allowed_methods]):


### PR DESCRIPTION
without this check (i.e. re.match instead of re.fullmatch),
e.g. ccsd3 would also fulfill the check   any(...)
now ccsd3 etc wlll not pass the check