### PR TITLE
Charge entry field (best is to squash commits when merging, otherwise a mess)

### DIFF
--- a/ProjectWindow.py
+++ b/ProjectWindow.py
@@ -442,6 +442,8 @@ class ProjectWindow(QMainWindow):
         self.guided_combo_wave_fct_symm.setCurrentText(
             self.input_specification['wave_fct_symm'] if 'wave_fct_symm' in self.input_specification else
             list(molpro_input.wave_fct_symm_commands.keys())[0])
+        if 'charge' in self.input_specification:
+            self.charge_line.setText(self.input_specification['charge'])
         if 'method' in self.input_specification:
             base_method = re.sub('[a-z]+-', '', self.input_specification['method'], flags=re.IGNORECASE)
             prefix = re.sub('-.*', '', self.input_specification['method']) if base_method != self.input_specification[

--- a/ProjectWindow.py
+++ b/ProjectWindow.py
@@ -404,6 +404,7 @@ class ProjectWindow(QMainWindow):
         self.charge_line = QLineEdit()
         self.charge_line.setValidator(QIntValidator())
         guided_form.addRow("Charge", self.charge_line)
+        self.charge_line.textChanged.connect(lambda text: self.input_specification_change('charge', text))
 
         self.guided_combo_wave_fct_symm = QComboBox()
         self.guided_combo_wave_fct_symm.addItems(molpro_input.wave_fct_symm_commands.keys())

--- a/ProjectWindow.py
+++ b/ProjectWindow.py
@@ -12,6 +12,7 @@ from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEnginePage, QWebEngineP
 from PyQt5.QtWidgets import QMainWindow, QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QComboBox, QLabel, \
     QMessageBox, QTabWidget, QFileDialog, QFormLayout, QLineEdit, \
     QSplitter, QMenu
+from PyQt5.QtGui import QIntValidator
 from pymolpro import Project
 
 import molpro_input
@@ -399,6 +400,10 @@ class ProjectWindow(QMainWindow):
         textLabel_wave_fct_char = QLabel()
         textLabel_wave_fct_char.setText("Wave Function Characteristics:")
         self.guided_layout.addWidget(textLabel_wave_fct_char)
+
+        self.charge_line = QLineEdit()
+        self.charge_line.setValidator(QIntValidator())
+        guided_form.addRow("Charge", self.charge_line)
 
         self.guided_combo_wave_fct_symm = QComboBox()
         self.guided_combo_wave_fct_symm.addItems(molpro_input.wave_fct_symm_commands.keys())

--- a/ProjectWindow.py
+++ b/ProjectWindow.py
@@ -404,7 +404,7 @@ class ProjectWindow(QMainWindow):
         self.charge_line = QLineEdit()
         self.charge_line.setValidator(QIntValidator())
         guided_form.addRow("Charge", self.charge_line)
-        self.charge_line.textChanged.connect(lambda text: self.input_specification_change('charge', text))
+        self.charge_line.textChanged.connect(lambda text: self.input_specification_variable_change('charge', text))
 
         self.guided_combo_wave_fct_symm = QComboBox()
         self.guided_combo_wave_fct_symm.addItems(molpro_input.wave_fct_symm_commands.keys())
@@ -442,8 +442,9 @@ class ProjectWindow(QMainWindow):
         self.guided_combo_wave_fct_symm.setCurrentText(
             self.input_specification['wave_fct_symm'] if 'wave_fct_symm' in self.input_specification else
             list(molpro_input.wave_fct_symm_commands.keys())[0])
-        if 'charge' in self.input_specification:
-            self.charge_line.setText(self.input_specification['charge'])
+        if 'variables' in self.input_specification:
+            if 'charge' in self.input_specification['variables']:
+                self.charge_line.setText(self.input_specification['variables']['charge'])
         if 'method' in self.input_specification:
             base_method = re.sub('[a-z]+-', '', self.input_specification['method'], flags=re.IGNORECASE)
             prefix = re.sub('-.*', '', self.input_specification['method']) if base_method != self.input_specification[
@@ -460,6 +461,12 @@ class ProjectWindow(QMainWindow):
 
     def input_specification_change(self, key, value):
         self.input_specification[key] = value
+        self.refresh_input_from_specification()
+
+    def input_specification_variable_change(self, key, value):
+        if 'variables' not in self.input_specification:
+            self.input_specification['variables']={}
+        self.input_specification['variables']['charge'] = value
         self.refresh_input_from_specification()
 
     def allowed_methods(self):

--- a/ProjectWindow.py
+++ b/ProjectWindow.py
@@ -11,6 +11,7 @@ from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEnginePage, QWebEngineP
 from PyQt5.QtWidgets import QMainWindow, QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QComboBox, QLabel, \
     QMessageBox, QTabWidget, QFileDialog, QDialogButtonBox, QFormLayout, QLineEdit, \
     QSplitter, QMenu
+from PyQt5.QtGui import QIntValidator
 from pymolpro import Project
 
 import molpro_input
@@ -397,6 +398,10 @@ class ProjectWindow(QMainWindow):
         textLabel_wave_fct_char = QLabel()
         textLabel_wave_fct_char.setText("Wave Function Characteristics:")
         self.guided_layout.addWidget(textLabel_wave_fct_char)
+
+        self.charge_line = QLineEdit()
+        self.charge_line.setValidator(QIntValidator())
+        guided_form.addRow("Charge", self.charge_line)
 
         self.guided_combo_wave_fct_symm = QComboBox()
         self.guided_combo_wave_fct_symm.addItems(molpro_input.wave_fct_symm_commands.keys())

--- a/ProjectWindow.py
+++ b/ProjectWindow.py
@@ -402,6 +402,7 @@ class ProjectWindow(QMainWindow):
         self.charge_line = QLineEdit()
         self.charge_line.setValidator(QIntValidator())
         guided_form.addRow("Charge", self.charge_line)
+        self.charge_line.textChanged.connect(lambda text: self.input_specification_change('charge', text))
 
         self.guided_combo_wave_fct_symm = QComboBox()
         self.guided_combo_wave_fct_symm.addItems(molpro_input.wave_fct_symm_commands.keys())

--- a/ProjectWindow.py
+++ b/ProjectWindow.py
@@ -440,6 +440,8 @@ class ProjectWindow(QMainWindow):
         self.guided_combo_wave_fct_symm.setCurrentText(
             self.input_specification['wave_fct_symm'] if 'wave_fct_symm' in self.input_specification else
             list(molpro_input.wave_fct_symm_commands.keys())[0])
+        if 'charge' in self.input_specification:
+            self.charge_line.setText(self.input_specification['charge'])
         if 'method' in self.input_specification:
             base_method = re.sub('[a-z]+-', '', self.input_specification['method'], flags=re.IGNORECASE)
             prefix = re.sub('-.*', '', self.input_specification['method']) if base_method != self.input_specification[

--- a/molpro_input.py
+++ b/molpro_input.py
@@ -69,7 +69,7 @@ def parse(input: str, allowed_methods: list, debug=False):
                     specification['wave_fct_symm'] = symmetry_command
                     break
         elif re.match('^charge *= *', line, re.IGNORECASE):
-            specification['charge'] = re.sub('^charge *= *', '', line + '\n', flags=re.IGNORECASE)
+            specification['charge'] = re.sub('^charge *= *', '', line, flags=re.IGNORECASE)
         elif re.match('^geometry *= *{', line, re.IGNORECASE):
             if 'precursor_methods' in specification: return {}  # input too complex
             if 'method' in specification: return {}  # input too complex

--- a/molpro_input.py
+++ b/molpro_input.py
@@ -68,8 +68,6 @@ def parse(input: str, allowed_methods: list, debug=False):
                 if (line.lower() == wave_fct_symm_commands[symmetry_command]):
                     specification['wave_fct_symm'] = symmetry_command
                     break
-        elif re.match('^charge *= *', line, re.IGNORECASE):
-            specification['charge'] = re.sub('^charge *= *', '', line, flags=re.IGNORECASE)
         elif re.match('^geometry *= *{', line, re.IGNORECASE):
             if 'precursor_methods' in specification: return {}  # input too complex
             if 'method' in specification: return {}  # input too complex
@@ -181,14 +179,13 @@ def create_input(specification: dict):
                                                                             specification[
                                                                                 'geometry']).rstrip(
             ' \n') + '\n' + ('' if 'geometry_external' in specification else '}\n')
-    if 'charge' in specification:
-        _input += 'charge='+specification['charge']+'\n'
 
     if 'basis' in specification:
         _input += 'basis={' + specification['basis'] + '}\n'
     if 'variables' in specification:
         for k, v in specification['variables'].items():
-            _input += k + '=' + v + '\n'
+            if v != '':
+                _input += k + '=' + v + '\n'
     if 'precursor_methods' in specification:
         for m in specification['precursor_methods']:
             _input += m + '\n'

--- a/molpro_input.py
+++ b/molpro_input.py
@@ -219,13 +219,14 @@ def basis_quality(specification):
 
 def canonicalise(input):
     result = re.sub('\n}', '}',
+                    re.sub(' *= *', '=',
                     re.sub('{\n', r'{',
                            re.sub('\n+', '\n',
                                   re.sub(' *, *', ',',
                                          re.sub('basis[=,] *([^{\n]+)\n',
                                                 r'basis={default=\1}\n',
                                                 input.replace(';',
-                                                              '\n')))))).rstrip(
+                                                              '\n'))))))).rstrip(
                                                                   '\n ').lstrip(
                                                                       '\n ') + '\n'
     new_result = ''

--- a/molpro_input.py
+++ b/molpro_input.py
@@ -169,6 +169,8 @@ def create_input(specification: dict):
     _input = ''
     if 'orientation' in specification:
         _input += 'orient,' + orientation_options[specification['orientation']]+'\n'
+    if 'charge' in specification:
+        print('KD Debug:', specification['charge'])
 
     if 'wave_fct_symm' in specification:
         _input += wave_fct_symm_commands[specification['wave_fct_symm']]+'\n'

--- a/molpro_input.py
+++ b/molpro_input.py
@@ -68,6 +68,8 @@ def parse(input: str, allowed_methods: list, debug=False):
                 if (line.lower() == wave_fct_symm_commands[symmetry_command]):
                     specification['wave_fct_symm'] = symmetry_command
                     break
+        elif re.match('^charge *= *', line, re.IGNORECASE):
+            specification['charge'] = re.sub('^charge *= *', '', line + '\n', flags=re.IGNORECASE)
         elif re.match('^geometry *= *{', line, re.IGNORECASE):
             if 'precursor_methods' in specification: return {}  # input too complex
             if 'method' in specification: return {}  # input too complex
@@ -169,8 +171,6 @@ def create_input(specification: dict):
     _input = ''
     if 'orientation' in specification:
         _input += 'orient,' + orientation_options[specification['orientation']]+'\n'
-    if 'charge' in specification:
-        _input += 'charge='+specification['charge']+'\n'
 
     if 'wave_fct_symm' in specification:
         _input += wave_fct_symm_commands[specification['wave_fct_symm']]+'\n'
@@ -181,6 +181,9 @@ def create_input(specification: dict):
                                                                             specification[
                                                                                 'geometry']).rstrip(
             ' \n') + '\n' + ('' if 'geometry_external' in specification else '}\n')
+    if 'charge' in specification:
+        _input += 'charge='+specification['charge']+'\n'
+
     if 'basis' in specification:
         _input += 'basis={' + specification['basis'] + '}\n'
     if 'variables' in specification:

--- a/molpro_input.py
+++ b/molpro_input.py
@@ -170,7 +170,7 @@ def create_input(specification: dict):
     if 'orientation' in specification:
         _input += 'orient,' + orientation_options[specification['orientation']]+'\n'
     if 'charge' in specification:
-        print('KD Debug:', specification['charge'])
+        _input += 'charge='+specification['charge']+'\n'
 
     if 'wave_fct_symm' in specification:
         _input += wave_fct_symm_commands[specification['wave_fct_symm']]+'\n'


### PR DESCRIPTION
allow to enter charge by user

to check:

1 ) charge is after geometry , before basis set
2) slightly pathological
`charge=1    234`
can be entered, is treated like charge=1 by Molpro
`charge=1 23 4`
gives error in Molpro

3 ) charge=5000 is possible for e.g. OH, and Molpro even runs
Molpro then says:

` NELEC=-4991   SYM=1   MS2=-1   THRE=1.0D-08   THRD=1.0D-06   THRG=1.0D-06  HFMA2=F  DIIS_START=2   DIIS_MAX=10   DIIS_INCORE=F
`
should this be trapped by Molpro? I guess I'll file a bug, because I just did optg and freq, without error,
but nonsense numbers.

4 ) somewhat unrelated:
is
`geometry={   `
or trailing line in geometry`  }`
allowed (cannot be converted to guided mode)