### PR TITLE
Option in guided mode to save orbitals to a molden file at the end of the job.

### DIFF
--- a/ProjectWindow.py
+++ b/ProjectWindow.py
@@ -533,7 +533,7 @@ class ProjectWindow(QMainWindow):
         self.guided_orbitals_input.setChecked(parameter)
 
     def orbital_put_command(self):
-        return 'put,molden,' + os.path.basename(os.path.splitext(self.project.filename())[0]) + '.molden'
+        return 'put,molden,' + os.path.basename(os.path.splitext(self.project.filename(run=-1))[0]) + '.molden'
 
     def refresh_guided_pane(self):
         if self.trace: print('refresh_guided_pane')

--- a/WindowManager.py
+++ b/WindowManager.py
@@ -48,6 +48,7 @@ class WindowManager:
                                          filename + ' already exists; please choose another file name')
                 else:
                     self.register(ProjectWindow(filename, self))
+                    self.openWindows[-1].orbitals_input_action(True)
                     return
             else:
                 return


### PR DESCRIPTION
 One day this might be a molpro xml file when jmol can support that.
The option is on by default, but might want it off for a very large molecule.
