### PR TITLE
Eliminate spin-case parsing - specification will now get, eg, 'method':'rks'

### DIFF
--- a/ProjectWindow.py
+++ b/ProjectWindow.py
@@ -434,6 +434,8 @@ class ProjectWindow(QMainWindow):
             self.input_tabs.removeTab(1)
         if guided and len(self.input_tabs) < 2:
             self.input_tabs.addTab(self.guided_pane, 'guided')
+        if guided:
+            self.input_specification = molpro_input.parse(self.input_pane.toPlainText(), self.allowed_methods())
 
     def guided_possible(self):
         input_text = self.input_pane.toPlainText()
@@ -463,9 +465,6 @@ class ProjectWindow(QMainWindow):
         for keyfound in self.procedures_registry.keys():
             if self.procedures_registry[keyfound]['class'] == 'PROG':
                 result.append(self.procedures_registry[keyfound]['name'])
-        for m in ['HF', 'KS']:
-            if 'R' + m in result: result[result.index('R' + m)] = m
-            if 'U' + m in result: del result[result.index('U' + m)]
         return result
 
     def vod_external_launch(self, command=''):

--- a/ProjectWindow.py
+++ b/ProjectWindow.py
@@ -1083,9 +1083,6 @@ class GuidedPane(QWidget):
         self.guided_combo_method.currentTextChanged.connect(
             lambda text: self.input_specification_change('method', text))
 
-        self.combo_uhf = QCheckBox(self)
-        self.combo_uhf.stateChanged.connect(lambda state: self.input_specification_change('spin_unrestricted_orbitals',  state!=0))
-
         self.combo_properties = PropertyInput(self)
 
         self.guided_layout.addWidget(RowOfTitledWidgets({
@@ -1102,7 +1099,6 @@ class GuidedPane(QWidget):
             'Charge': self.charge_line,
             'Spin': self.spin_line,
             'Symmetry': self.guided_combo_wave_fct_symm,
-            'UHF': self.combo_uhf,
         }, title='Wavefunction parameters'))
 
         self.guided_orbitals_input = OrbitalInput(self)
@@ -1145,9 +1141,6 @@ class GuidedPane(QWidget):
         #     self.guided_basis_input.setText('TODO get rid of this: '+str(self.input_specification['basis']))
         if 'job_type' in self.input_specification:
             self.guided_combo_job_type.setCurrentText(self.input_specification['job_type'])
-        self.combo_uhf.setChecked(
-            'spin_unrestricted_orbitals' in self.input_specification and self.input_specification[
-                'spin_unrestricted_orbitals'])
 
         self.basis_and_hamiltonian_chooser.refresh()
 

--- a/molpro_input.py
+++ b/molpro_input.py
@@ -173,7 +173,6 @@ def parse(input: str, allowed_methods=[], debug=False):
                   df_prefix
                   in df_prefixes
                   for local_prefix in local_prefixes for method in allowed_methods]):
-            print('setting method', line.lower())
             parse_method(specification, line.lower())
         elif command != '' and (any(
                 [command.lower() == re.sub('.*; ', '', job_type_commands[job_type].lower()) for job_type in

--- a/molpro_input_test.py
+++ b/molpro_input_test.py
@@ -1,7 +1,7 @@
 from molpro_input import parse, create_input, basis_quality, equivalent, canonicalise
 import time
 
-allowed_methods_ = ['HF', 'CCSD', 'RKS', 'CASSCF', 'MRCI']
+allowed_methods_ = ['RHF', 'CCSD', 'RKS', 'CASSCF', 'MRCI']
 
 
 def test_file(qtbot, tmpdir):
@@ -13,6 +13,21 @@ def test_file(qtbot, tmpdir):
 
 
 def test_create_input(qtbot):
+    for specification in [
+        {'job_type': 'Single Point Energy', 'geometry': 'F\nH,F,1.7\n',
+         'basis': {'default': 'cc-pVTZ', 'elements': {}, 'quality': 3},
+         'precursor_methods': ['{rks,b3lyp}'], 'method': 'ccsd', 'hamiltonian': 'AE', 'method_options': ''},
+        {'job_type': 'Single Point Energy', 'geometry': 'F\nH,F,1.7\n',
+         'basis': {'default': 'cc-pVTZ', 'elements': {}, 'quality': 3},
+         'precursor_methods': [], 'method': 'rks', 'density_functional': 'b3lyp', 'hamiltonian': 'AE', 'method_options': ''},
+        {'job_type': 'Single Point Energy', 'geometry': 'F\nH,F,1.7\n',
+         'basis': {'default': 'cc-pVTZ', 'elements': {}, 'quality': 3},
+         'precursor_methods': [], 'method': 'rhf', 'hamiltonian': 'AE', 'method_options': 'b3lyp'},
+    ]:
+        # print(create_input(specification))
+        # print('new_specification', parse(create_input(specification), allowed_methods=allowed_methods_))
+        assert parse(create_input(specification), allowed_methods=allowed_methods_) == specification
+
     for test_text in [
         'Geometry={F;H,F,1.7};basis={default=cc-pVTZ,h=cc-pVDZ} !some comment;{ks,b3lyp};locali\nccsd\n',
         'Geometry={\nF;H,F,1.7};basis={default=cc-pVTZ,h=cc-pVDZ} !some comment;{ks,b3lyp};locali\nccsd\n',
@@ -23,9 +38,15 @@ def test_create_input(qtbot):
         'geometry=thing.xyz',
         'geometry={H};uhf',
         'geometry={H};{uhf}',
+        'geometry={H};{rhf}',
+        'geometry={H};{hf}',
         'geometry={H};{uks,b3lyp};ccsd',
+        'geometry={H};{rks,b3lyp};ccsd',
+        'geometry={H};{ks,b3lyp};ccsd',
         'geometry={H};uks,b3lyp;ccsd',
         'geometry={H};uks,b3lyp',
+        'geometry={H};rks,b3lyp',
+        'geometry={H};ks,b3lyp',
     ]:
         # print('test_text', test_text)
         specification = parse(test_text, allowed_methods=allowed_methods_)


### PR DESCRIPTION
Parse into specification `density_functional` and `method_options`
