### PR TITLE
set functional in pulldown according to freehand input, if possible

### DIFF
--- a/ProjectWindow.py
+++ b/ProjectWindow.py
@@ -1153,6 +1153,9 @@ class GuidedPane(QWidget):
             self.guided_combo_method.setCurrentIndex(method_index)
         # if 'basis' in self.input_specification:
         #     self.guided_basis_input.setText('TODO get rid of this: '+str(self.input_specification['basis']))
+        if 'density_functional' in self.input_specification:
+            density_functional_index = self.guided_combo_functional.findText(self.input_specification['density_functional'], Qt.MatchFixedString)
+            self.guided_combo_functional.setCurrentIndex(density_functional_index)
         if 'job_type' in self.input_specification:
             self.guided_combo_job_type.setCurrentText(self.input_specification['job_type'])
 

--- a/ProjectWindow.py
+++ b/ProjectWindow.py
@@ -1175,6 +1175,8 @@ class GuidedPane(QWidget):
         return 'put,molden,' + os.path.basename(os.path.splitext(self.project.filename(run=-1))[0]) + '.molden'
 
     def input_specification_change(self, key, value):
+        if not value:
+            return
         self.input_specification[key] = value
         if key == 'method':
             self.input_specification['precursor_methods'] = []


### PR DESCRIPTION
This sets the functional according to what is chosen in freehand.

Yet wrong: when the functional is non-existent such as
`rks,bla12345`
, it still allows to switch to guided mode