### PR TITLE
trap the case that molpro is not found

### DIFF
--- a/ProjectWindow.py
+++ b/ProjectWindow.py
@@ -452,10 +452,11 @@ class ProjectWindow(QMainWindow):
     def available_functionals(self):
         project_registry = self.project.registry('dfunc')
         result = []
-        for priority in range(5,-1,-1):
-            for keyfound in project_registry:
-                if project_registry[keyfound]['priority'] == priority:
-                    result.append(keyfound)
+        if project_registry != None :
+            for priority in range(5,-1,-1):
+                for keyfound in project_registry:
+                    if project_registry[keyfound]['priority'] == priority:
+                        result.append(keyfound)
         return result
 
     def allowed_methods(self):


### PR DESCRIPTION
otherwise crashes with:
```
  File "Chooser.py", line 176, in newProjectDialog
  File "WindowManager.py", line 52, in new
  File "ProjectWindow.py", line 205, in __init__
  File "ProjectWindow.py", line 1096, in __init__
  File "ProjectWindow.py", line 456, in available_functionals
TypeError: 'NoneType' object is not iterable
Aborted (core dumped)
```