### PR TITLE
Include zero-frequency normal coordinates in the vibrations model, so that the indexing in jmol selection of vibrations works correctly for imaginary-frequency modes.

### DIFF
--- a/utilities.py
+++ b/utilities.py
@@ -504,7 +504,7 @@ class VibrationSetXML(VibrationSet):
                 'real_zero_imag': c.attrib['real_zero_imag'],
             }
             for c in (vibrations_node[instance].xpath(
-                'molpro-output:normalCoordinate[not(@real_zero_imag) or @real_zero_imag!="Z"]',
+                'molpro-output:normalCoordinate',
                 namespaces=namespaces_))
         ]
 


### PR DESCRIPTION
Fixes #300
