### PR TITLE
Add View menu item for Slurm job output; grey out unavailable file views

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-#        os: [ ubuntu-24.04, ubuntu-24.04-arm, macos-latest, macos-15-intel ]
-        os: [ ubuntu-24.04, macos-latest]
+        os: [ ubuntu-24.04, ubuntu-24.04-arm, macos-latest, macos-15-intel ]
         include:
           - os: macos-latest
             mac: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dynamic = ["version"]
 dependencies = [
     "pyside6<6.10",
     "pymolpro>=1.20.2",
-    "pysjef>=1.45.18",
+    "pysjef>=1.45.20",
     "pubchempy>=1",
     "chemspipy>=2",
     "jsonschema>=4",

--- a/src/iMolpro/ProjectWindow.py
+++ b/src/iMolpro/ProjectWindow.py
@@ -232,6 +232,7 @@ class ProjectWindow(QMainWindow):
         self.output_tabs = OutputTabWidget(self)
         self.timer_output_tabs = QTimer(self)
         self.timer_output_tabs.timeout.connect(self.output_tabs.refresh)
+        self.timer_output_tabs.timeout.connect(self.update_view_menu_actions)
         self.timer_output_tabs.start(1000)
         splitter.addWidget(self.output_tabs)
         splitter.setStretchFactor(1, 2147483647)
@@ -515,6 +516,25 @@ class ProjectWindow(QMainWindow):
     def show_xyz_output(self):
         self.show_xyz(0)
         pass
+
+    def update_view_menu_actions(self):
+        for suffix, action in getattr(self, 'view_file_actions', {}).items():
+            try:
+                filename = self.project.filename(suffix)
+                exists = bool(filename) and os.path.isfile(filename) and os.path.getsize(filename) > 0
+            except Exception:
+                exists = False
+            action.setEnabled(exists)
+        for action, instance in getattr(self, 'view_xyz_actions', []):
+            exists = False
+            try:
+                exists = any(
+                    os.path.isfile(self.project.filename('', file[1], instance))
+                    for file in self.geometry_files()
+                )
+            except Exception:
+                exists = False
+            action.setEnabled(exists)
 
     def visualise_input(self, external_path=None):
         # logger.debug('visualise_input' + str(self.vods.keys()))

--- a/src/iMolpro/project.py
+++ b/src/iMolpro/project.py
@@ -1,3 +1,5 @@
+import glob
+import os
 from dataclasses import dataclass
 
 import lxml
@@ -5,6 +7,11 @@ from pymolpro import Project as BaseProject
 from pymolpro.defbas import periodic_table
 
 from .utilities import VibrationSetXML
+
+# Pseudo-suffix for filename(): the output file written by a Slurm batch job. Slurm's naming
+# isn't known to sjef, so unlike the other suffixes it can't be looked up via the normal
+# suffix->filename mapping and has to be found by globbing the run directory instead.
+SLURM_OUTPUT_SUFFIX = 'slurm_out'
 
 
 @dataclass
@@ -24,9 +31,30 @@ class Project(BaseProject):
         if type(self.run_directory) != int:
             raise Exception('run_directory must be an integer ' + str(self.run_directory))
         # print('filename', suffix, 'name=',name, 'run=', run, 'self.run_directory=',self.run_directory)
-        filename = super().filename(suffix, name, self.run_directory if run == 0 else run)
+        run = self.run_directory if run == 0 else run
+        if suffix == SLURM_OUTPUT_SUFFIX and not name:
+            return self._slurm_output_filename(run)
+        filename = super().filename(suffix, name, run)
         # print('evaluated filename',filename)
         return filename
+
+    def _slurm_output_filename(self, run) -> str:
+        """
+        Find the file written by a Slurm batch job's output redirection for the given run, if
+        any. Its name is controlled by the user's own job-submission script, not by sjef or
+        iMolpro, so the only thing that can be assumed about it is that it contains 'slurm'
+        somewhere in the name (including the suffix). If the project's own name also contains
+        'slurm', that alone isn't enough to tell a real Slurm output file apart from any other
+        run-directory file that happens to start with the project name, so in that case require
+        'slurm' to appear twice.
+        """
+        run_directory = os.path.dirname(super().filename('out', '', run))
+        minimum_occurrences = 2 if 'slurm' in self.name else 1
+        matches = [
+            f for f in glob.glob(os.path.join(run_directory, '*slurm*'))
+            if os.path.isfile(f) and os.path.basename(f).count('slurm') >= minimum_occurrences
+        ]
+        return max(matches, key=os.path.getmtime) if matches else ''
 
     @property
     def run_directory_names(self) -> list[str]:

--- a/src/iMolpro/project_window_menu.py
+++ b/src/iMolpro/project_window_menu.py
@@ -19,6 +19,7 @@ from .settings import settings, settings_edit
 from .theme import THEMES, detect_system_theme
 from .help import help_manager_default
 from .backend import configure_backend
+from .project import SLURM_OUTPUT_SUFFIX
 
 
 def setup_project_window_menubar(window):
@@ -102,10 +103,14 @@ def setup_project_window_menubar(window):
         action.triggered.connect(lambda checked, theme_name=theme_name: window.set_theme(theme_name))
     menubar.addSubmenu(theme_menu, 'View')
     menubar.addSeparator('View')
-    menubar.addAction('Initial structure xyz', 'View', window.show_xyz_input,
-                      tooltip='View the xyz file for the molecular structure in the job input')
-    menubar.addAction('Final structure xyz', 'View', window.show_xyz_output,
-                      tooltip='View the xyz file for the molecular structure at the end of the job')
+    # (action, instance) pairs consulted by update_view_menu_actions() to grey out actions
+    # whose target file doesn't exist yet.
+    window.view_xyz_actions = [
+        (menubar.addAction('Initial structure xyz', 'View', window.show_xyz_input,
+                           tooltip='View the xyz file for the molecular structure in the job input'), -1),
+        (menubar.addAction('Final structure xyz', 'View', window.show_xyz_output,
+                           tooltip='View the xyz file for the molecular structure at the end of the job'), 0),
+    ]
     if window.external_viewer_commands:
         window.external_menu = QMenu('View molecule in external program...')
         for command in window.external_viewer_commands.keys():
@@ -121,12 +126,23 @@ def setup_project_window_menubar(window):
         (window.output_tabs.currentIndex() - 1) % len(window.output_tabs)), 'Alt+[')
 
     menubar.addSeparator('View')
-    menubar.addAction('Job output', 'View', lambda: window.output_tabs.add_suffix('out'), shortcut='Alt+o')
-    menubar.addAction('Job input', 'View', lambda: window.output_tabs.add_suffix('inp'), shortcut='Alt+i')
-    menubar.addAction('Job log', 'View', lambda: window.output_tabs.add_suffix('log'), shortcut='Alt+l')
-    menubar.addAction('Job xml', 'View', lambda: window.output_tabs.add_suffix('xml'), shortcut='Alt+x')
-    menubar.addAction('Job stdout', 'View', lambda: window.output_tabs.add_suffix('stdout'))
-    menubar.addAction('Job stderr', 'View', lambda: window.output_tabs.add_suffix('stderr'))
+    # suffix -> action, consulted by update_view_menu_actions() to grey out actions whose
+    # target file doesn't exist yet.
+    window.view_file_actions = {
+        'out': menubar.addAction('Job output', 'View', lambda: window.output_tabs.add_suffix('out'),
+                                 shortcut='Alt+o'),
+        'inp': menubar.addAction('Job input', 'View', lambda: window.output_tabs.add_suffix('inp'),
+                                 shortcut='Alt+i'),
+        'log': menubar.addAction('Job log', 'View', lambda: window.output_tabs.add_suffix('log'),
+                                 shortcut='Alt+l'),
+        'xml': menubar.addAction('Job xml', 'View', lambda: window.output_tabs.add_suffix('xml'),
+                                 shortcut='Alt+x'),
+        'stdout': menubar.addAction('Job stdout', 'View', lambda: window.output_tabs.add_suffix('stdout')),
+        'stderr': menubar.addAction('Job stderr', 'View', lambda: window.output_tabs.add_suffix('stderr')),
+        SLURM_OUTPUT_SUFFIX: menubar.addAction('Job Slurm output', 'View',
+                                              lambda: window.output_tabs.add_suffix(SLURM_OUTPUT_SUFFIX)),
+    }
+    window.update_view_menu_actions()
 
     window.run_action = menubar.addAction('Run', 'Job', window.run, 'Ctrl+R', 'Run Molpro on the project input')
     window.run_force_action = menubar.addAction('Run (force)', 'Job', window.run_force, 'Ctrl+Shift+R',


### PR DESCRIPTION
## Summary
- Add a "Job Slurm output" item to the `View` menu, alongside the existing stdout/stderr/log/etc. viewers.
- Since Slurm's own output-file naming is controlled by the user's job-submission script (not sjef or iMolpro), it's located by globbing the run directory for a file containing `slurm` in its name — requiring two occurrences when the project name itself contains "slurm", to disambiguate a real Slurm output file from an unrelated project file.
- Grey out every `View` menu item that shows a file (`Job output`/`input`/`log`/`xml`/`stdout`/`stderr`/`Slurm output`, `Initial`/`Final structure xyz`) whenever its target file doesn't exist yet, refreshed on the same 1-second timer that already drives the output tabs.

## Test plan
- [x] `python -m pytest` — 27 passed (pre-existing `qtbot` fixture error in `EditFile_test.py` is unrelated/environmental)
- [x] Isolated tests of `Project.filename('slurm_out')` glob/disambiguation logic (normal name, project name containing "slurm", no match)
- [x] Headless (`QT_QPA_PLATFORM=offscreen`) smoke test opening a `ProjectWindow`: confirmed `View` actions start disabled except `Job input`, and become enabled after creating matching `.stdout` / `*slurm*.out` files in the run directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)