### PR TITLE
Fix regression: nuclei lose element colours until vibration Animate is toggled

### DIFF
--- a/src/iMolpro/vtk_molecule_widget.py
+++ b/src/iMolpro/vtk_molecule_widget.py
@@ -970,15 +970,14 @@ class NucleiActor(vtkActor):
         self.update_data(source)
         mapper.SetInputConnection(self.glyph.GetOutputPort())
         self.SetMapper(mapper)
-
-    def set_sphere_resolution(self, resolution: int):
-        self.sphere_source.SetPhiResolution(resolution)
-        self.sphere_source.SetThetaResolution(resolution)
         self.GetProperty().SetColor(vtkNamedColors().GetColor3d('Salmon'))
         if self.atomic_number is not None:
             self.GetProperty().SetColor(colors.cpk_colors[self.atomic_number])
         self.SetOrigin(0.0, 0.0, 0.0)
-        # self.GetProperty().SetOpacity(.1)
+
+    def set_sphere_resolution(self, resolution: int):
+        self.sphere_source.SetPhiResolution(resolution)
+        self.sphere_source.SetThetaResolution(resolution)
 
 
 class NucleusLabelsActor(vtkActor2D):


### PR DESCRIPTION
## Summary
- Fixes a regression from #386: on first showing a structure with vibration data, nucleus spheres rendered white instead of their element (CPK) colours, until the "Animate" checkbox was ticked once — after which colours stayed correct even with Animate off again.
- Root cause: `NucleiActor.set_source()` was split into `set_source()` and a new `set_sphere_resolution()` to support dropping sphere tessellation while animating. The colour (and `SetOrigin`) assignment lines were accidentally carried over into `set_sphere_resolution()` along with the resolution lines, instead of staying in `set_source()`. Since `set_sphere_resolution()` is only called from the animate start/stop paths, colour was never set at construction — only as a side effect of the first Animate toggle.
- Fix: move colour/origin assignment back into `set_source()`; `set_sphere_resolution()` now only sets phi/theta resolution.

## Test plan
- [x] `python -m pytest` (28/28 passing)
- [x] Verified via direct VTK property inspection: nucleus actor colours are correct immediately after construction (before any render or Animate toggle), and remain correct through animate-on/animate-off cycles
- [x] Verified via `vtkWindowToImageFilter` pixel capture that red/blue element colours are present in the very first render

🤖 Generated with [Claude Code](https://claude.com/claude-code)